### PR TITLE
Remove retired goreportcard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GitHub release](https://img.shields.io/github/release/UnitVectorY-Labs/iapheaders.svg)](https://github.com/UnitVectorY-Labs/iapheaders/releases/latest) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Active](https://img.shields.io/badge/Status-Active-green)](https://guide.unitvectorylabs.com/bestpractices/status/#active) [![Go Report Card](https://goreportcard.com/badge/github.com/UnitVectorY-Labs/iapheaders)](https://goreportcard.com/report/github.com/UnitVectorY-Labs/iapheaders)
+[![GitHub release](https://img.shields.io/github/release/UnitVectorY-Labs/iapheaders.svg)](https://github.com/UnitVectorY-Labs/iapheaders/releases/latest) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![Active](https://img.shields.io/badge/Status-Active-green)](https://guide.unitvectorylabs.com/bestpractices/status/#active)
 
 # iapheaders
 


### PR DESCRIPTION
goreportcard.com has been retired. Removing the badge.